### PR TITLE
Feat: Use latest zone and scheme area polygons

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -126,30 +126,13 @@ view.ui.add(scaleBar, {
   position: "bottom-right"
 });
 
-// TODO: Display queryDiv only after DOM content is fully loaded
 const queryPanel = document.getElementById("queryDiv");
-queryPanel.style.display = "block";
 
-// // Assign web layer once webmap is loaded and initialize UI
-// webmap.load().then(function () {
-//   webLayer = webmap.layers.find(function (layer) {
-//     // title of layer, not name of the webmap
-//     return layer.title === "ZONE_nonSea_planAttr_MASTER_30DEC2020";
-//   });
-//   // Fetch all fields
-//   // https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-FeatureLayer.html#outFields
-//   webLayer.outFields = ["*"];
-
-//   // Show query UI only after the map is loaded
-//   view.whenLayerView(webLayer).then(function (layerView) {
-//     webLayerView = layerView;
-//     queryDiv.style.display = "block";
-//   });
-
-//   // Put OZP zoning feature layer to the bottom, otherwise query geoms will be hided by the OZP polygons
-//   // https://developers.arcgis.com/javascript/latest/api-reference/esri-Map.html#reorder
-//   webmap.reorder(webLayer, 0);
-// });
+zone
+  .load()
+  .then(() => {
+    queryPanel.style.display = "block";
+  });
 
 view.ui.add([queryDiv], "bottom-left");
 

--- a/app/main.js
+++ b/app/main.js
@@ -55,8 +55,7 @@ const sketchLayer = new GraphicsLayer();
 const bufferLayer = new GraphicsLayer();
 view.map.addMany([bufferLayer, sketchLayer]);
 
-let webLayer = null;
-let webLayerView = null;
+const featureToQuery = zone;
 let bufferSize = 0;
 
 // https://developers.arcgis.com/javascript/latest/sample-code/widgets-scalebar/index.html
@@ -452,7 +451,7 @@ async function getZoningAreaInBuffer (bufferLength, zoning) {
 
   let areaInBuffer = 0;
 
-  const query = webLayerView.createQuery();
+  const query = featureToQuery.createQuery();
 
   query.geometry = sketchGeometry;
   query.distance = bufferLength;
@@ -465,7 +464,7 @@ async function getZoningAreaInBuffer (bufferLength, zoning) {
     console.log(`Query zoning of ${zoning} intersects with buffer`);
   }
 
-  const results = await webLayerView.queryFeatures(query);
+  const results = await featureToQuery.queryFeatures(query);
 
   // console.log("Queried zoning intersects with buffer");
   // console.log(results);
@@ -538,7 +537,7 @@ function highlightGeometries (objectIds) {
   const objectIdField = webLayer.objectIdField;
   document.getElementById("count").innerHTML = objectIds.length;
 
-  highlightHandle = webLayerView.highlight(objectIds);
+  highlightHandle = featureToQuery.highlight(objectIds);
 }
 
 // Change count of features within buffer
@@ -547,12 +546,12 @@ function changeFeatureCount (objectIds) {
 }
 
 function updateMapLayer () {
-  const query = webLayerView.createQuery();
+  const query = featureToQuery.createQuery();
 
   query.geometry = sketchGeometry;
   query.distance = bufferSize;
 
-  return webLayerView.queryObjectIds(query).then(changeFeatureCount);
+  return featureToQuery.queryObjectIds(query).then(changeFeatureCount);
   // return webLayerView.queryObjectIds(query).then(highlightGeometries);
 }
 
@@ -600,14 +599,14 @@ const statDefinitions = [{
 
 function queryStatistics () {
   // https://developers.arcgis.com/javascript/latest/api-reference/esri-tasks-support-Query.html
-  const query = webLayerView.createQuery();
+  const query = featureToQuery.createQuery();
 
   query.geometry = sketchGeometry;
   query.distance = bufferSize;
   query.outStatistics = statDefinitions;
 
   // with outStatistics returned result is a "table" with geometry of null
-  return webLayerView.queryFeatures(query).then(function (result) {
+  return featureToQuery.queryFeatures(query).then(function (result) {
     // console.log(result);
 
     const allStats = result.features[0].attributes;

--- a/app/main.js
+++ b/app/main.js
@@ -21,9 +21,66 @@ const map = new Map({
   basemap: "gray-vector"
 });
 
+const zonePopupTemplate = new PopupTemplate({
+  title: "Zoning Details",
+  defaultPopupTemplateEnabled: true,
+  content: [
+    {
+      type: "fields",
+      fieldInfos: [
+        {
+          fieldName: "ZONE_LABEL",
+          label: "ZONE_LABEL"
+        },
+        {
+          fieldName: "DESC_ENG",
+          label: "DESC_ENG"
+        },
+        {
+          fieldName: "DESC_CHT",
+          label: "DESC_CHT"
+        },
+        {
+          fieldName: "SPUSE_ENG",
+          label: "SPUSE_ENG"
+        },
+        {
+          fieldName: "SPUSE_CHT",
+          label: "SPUSE_CHT"
+        },
+        {
+          fieldName: "PLAN_NO",
+          label: "PLAN_NO"
+        },
+        {
+          fieldName: "NAME_ENG",
+          label: "NAME_ENG"
+        },
+        {
+          fieldName: "NAME_CHT",
+          label: "NAME_CHT"
+        },
+        {
+          fieldName: "PUB_DATE",
+          label: "PUB_DATE"
+        },
+        {
+          fieldName: "APRV_DATE",
+          label: "APRV_DATE"
+        },
+        {
+          fieldName: "SECT_NO",
+          label: "SECT_NO"
+        }
+      ]
+    }
+  ]
+});
+
 const zone = new FeatureLayer({
   url: "https://services5.arcgis.com/xH8UmTNerx1qYfXM/ArcGIS/rest/services/ZONE_MASTER_LATEST/FeatureServer",
-  outFields: ["*"]
+  outFields: ["*"],
+  popupTemplate: zonePopupTemplate
 });
 
 const schemeArea = new FeatureLayer({

--- a/index.html
+++ b/index.html
@@ -52,9 +52,6 @@
     <div id="contentDiv">
       <h2>Query land use zonings by geometries</h2>
       <p>
-        <b>NOTE: This application is still under development. The OZP data last updated on 30 Dec 2020.</b>
-      </p>
-      <p>
         This is a web map application to interactively explore the land use zonings in Hong Kong.
         You can investigate the distribution of zonings in any area of interest, as well as their proximities.
       </p>


### PR DESCRIPTION
- Update to use the latest version OZP materials, including ZONE and SCHEME_AREA
- Directly load the FeatureLayer from hosted feature services (i.e. FeatureServer), instead of [WebMap](https://doc.arcgis.com/en/arcgis-online/create-maps/make-your-first-map.htm) from ArcGIS Online