### PR TITLE
Refactor: Move functions to separate files

### DIFF
--- a/app/buffer.js
+++ b/app/buffer.js
@@ -1,0 +1,36 @@
+import { geodesicBuffer } from "@arcgis/core/geometry/geometryEngine";
+import Graphic from "@arcgis/core/Graphic";
+
+// update graphic and size figure of buffer
+export function updateBufferGraphic (buffer, sketchGeometry, bufferLayer) {
+  // add a polygon graphic for the buffer
+  if (buffer > 0) {
+    const bufferGeometry = geodesicBuffer(
+      sketchGeometry,
+      buffer,
+      "meters"
+    );
+    // graphic layer can contain multiple features (i.e. length > 1)
+    if (bufferLayer.graphics.length === 0) {
+      bufferLayer.add(
+        new Graphic({
+          geometry: bufferGeometry,
+          // symbol: sketchViewModel.polygonSymbol,
+          symbol: {
+            type: "simple-fill",
+            color: [151, 151, 204, 0.5],
+            style: "solid",
+            outline: {
+              color: "white",
+              width: 1
+            }
+          }
+        })
+      );
+    } else {
+      bufferLayer.graphics.getItemAt(0).geometry = bufferGeometry;
+    }
+  } else {
+    bufferLayer.removeAll();
+  }
+}

--- a/app/main.js
+++ b/app/main.js
@@ -336,7 +336,7 @@ const debouncedCalculateZoningArea = debounce((selectedZonings) => {
 });
 
 async function runQuery () {
-  // Update the vuew of buffer graphic layer on map
+  // Update the view of buffer graphic layer on map
   updateBufferGraphic(bufferSize, sketchGeometry, bufferLayer);
   // Update geometry stats
   updateQueryGeomSize(sketchGeometry, bufferSize);
@@ -518,43 +518,6 @@ async function getZoningAreaInBuffer (bufferLength, zoning) {
   }
 
   return areaInBuffer;
-}
-
-// Calculate geodesic area of a graphic layer (multiple features possible)
-// https://community.esri.com/t5/arcgis-api-for-javascript/calculate-geodesic-area-of-polygon/td-p/367598
-function calculateGeodesicArea (graphicsLayer) {
-  // TODO
-
-  // var GeodesicArea = 0
-  //
-  // graphicsLayer.graphics.map(function (grap) {
-  //   GeodesicArea = geodesicArea(grap.geometry, "square-meters");
-  // });
-  //
-  // return GeodesicArea;
-}
-
-// Highlight feautres within buffer area
-// Not used now
-
-let highlightHandle = null;
-
-function clearHighlighting () {
-  if (highlightHandle) {
-    highlightHandle.remove();
-    highlightHandle = null;
-  }
-}
-
-// Highlight (i.e. select) the geometries selected in the OZP layer
-function highlightGeometries (objectIds) {
-  // Remove any previous highlighting
-  clearHighlighting();
-
-  const objectIdField = webLayer.objectIdField;
-  document.getElementById("count").innerHTML = objectIds.length;
-
-  highlightHandle = featureToQuery.highlight(objectIds);
 }
 
 // Change count of features within buffer

--- a/app/main.js
+++ b/app/main.js
@@ -126,30 +126,13 @@ view.ui.add(scaleBar, {
   position: "bottom-right"
 });
 
-// TODO: Display queryDiv only after DOM content is fully loaded
 const queryPanel = document.getElementById("queryDiv");
-queryPanel.style.display = "block";
 
-// // Assign web layer once webmap is loaded and initialize UI
-// webmap.load().then(function () {
-//   webLayer = webmap.layers.find(function (layer) {
-//     // title of layer, not name of the webmap
-//     return layer.title === "ZONE_nonSea_planAttr_MASTER_30DEC2020";
-//   });
-//   // Fetch all fields
-//   // https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-FeatureLayer.html#outFields
-//   webLayer.outFields = ["*"];
-
-//   // Show query UI only after the map is loaded
-//   view.whenLayerView(webLayer).then(function (layerView) {
-//     webLayerView = layerView;
-//     queryDiv.style.display = "block";
-//   });
-
-//   // Put OZP zoning feature layer to the bottom, otherwise query geoms will be hided by the OZP polygons
-//   // https://developers.arcgis.com/javascript/latest/api-reference/esri-Map.html#reorder
-//   webmap.reorder(webLayer, 0);
-// });
+zone
+  .load()
+  .then(() => {
+    queryPanel.style.display = "block";
+  });
 
 view.ui.add([queryDiv], "bottom-left");
 

--- a/app/main.js
+++ b/app/main.js
@@ -513,13 +513,13 @@ async function getZoningAreaInBuffer (bufferLength, zoning) {
     );
 
     // "Union" to merge the selected OZP zones into one single layer for intersect use
-    const unionGeoms = await union(selectedOZPGeoms);
+    const unionGeoms = union(selectedOZPGeoms);
     // console.log("union function performed");
 
-    const bufferOZPIntersect = await intersect(bufferGeometry, unionGeoms);
+    const bufferOZPIntersect = intersect(bufferGeometry, unionGeoms);
     // console.log("intersect function performed");
 
-    areaInBuffer = await geodesicArea(bufferOZPIntersect, "square-meters");
+    areaInBuffer = geodesicArea(bufferOZPIntersect, "square-meters");
   }
 
   return areaInBuffer;

--- a/app/main.js
+++ b/app/main.js
@@ -55,8 +55,7 @@ const sketchLayer = new GraphicsLayer();
 const bufferLayer = new GraphicsLayer();
 view.map.addMany([bufferLayer, sketchLayer]);
 
-let webLayer = null;
-let webLayerView = null;
+const featureToQuery = zone;
 let bufferSize = 0;
 
 // https://developers.arcgis.com/javascript/latest/sample-code/widgets-scalebar/index.html
@@ -452,7 +451,7 @@ async function getZoningAreaInBuffer (bufferLength, zoning) {
 
   let areaInBuffer = 0;
 
-  const query = webLayerView.createQuery();
+  const query = featureToQuery.createQuery();
 
   query.geometry = sketchGeometry;
   query.distance = bufferLength;
@@ -465,7 +464,7 @@ async function getZoningAreaInBuffer (bufferLength, zoning) {
     console.log(`Query zoning of ${zoning} intersects with buffer`);
   }
 
-  const results = await webLayerView.queryFeatures(query);
+  const results = await featureToQuery.queryFeatures(query);
 
   // console.log("Queried zoning intersects with buffer");
   // console.log(results);
@@ -538,7 +537,7 @@ function highlightGeometries (objectIds) {
   const objectIdField = webLayer.objectIdField;
   document.getElementById("count").innerHTML = objectIds.length;
 
-  highlightHandle = webLayerView.highlight(objectIds);
+  highlightHandle = featureToQuery.highlight(objectIds);
 }
 
 // Change count of features within buffer
@@ -547,12 +546,12 @@ function changeFeatureCount (objectIds) {
 }
 
 function updateMapLayer () {
-  const query = webLayerView.createQuery();
+  const query = featureToQuery.createQuery();
 
   query.geometry = sketchGeometry;
   query.distance = bufferSize;
 
-  return webLayerView.queryObjectIds(query).then(changeFeatureCount);
+  return featureToQuery.queryObjectIds(query).then(changeFeatureCount);
   // return webLayerView.queryObjectIds(query).then(highlightGeometries);
 }
 
@@ -600,14 +599,14 @@ const statDefinitions = [{
 
 function queryStatistics () {
   // https://developers.arcgis.com/javascript/latest/api-reference/esri-tasks-support-Query.html
-  const query = webLayerView.createQuery();
+  const query = featureToQuery.createQuery();
 
   query.geometry = sketchGeometry;
   query.distance = bufferSize;
   query.outStatistics = statDefinitions;
 
   // with outStatistics returned result is a "table" with geometry of null
-  return webLayerView.queryFeatures(query).then(function (result) {
+  return featureToQuery.queryFeatures(query).then(function (result) {
     // console.log(result);
 
     const allStats = result.features[0].attributes;

--- a/app/main.js
+++ b/app/main.js
@@ -355,6 +355,8 @@ async function runQuery () {
   // query statstics inside the buffer and change the chart
   const zoneStats = await queryStatistics(featureToQuery, sketchGeometry, bufferSize);
 
+  console.log(zoneStats);
+
   updateChart(zoningNumberChart, [
     zoneStats.zone_RA,
     zoneStats.zone_RB,
@@ -366,7 +368,8 @@ async function runQuery () {
     zoneStats.zone_OTHERS
   ]);
 
-  updateMapLayer();
+  updateZoningPiecesCount(zoneStats);
+
 
   // scroll to the results
   const elmnt = document.querySelector(".query-stats");
@@ -555,19 +558,12 @@ function highlightGeometries (objectIds) {
 }
 
 // Change count of features within buffer
-function changeFeatureCount (objectIds) {
-  document.getElementById("count").innerHTML = objectIds.length;
-}
+function updateZoningPiecesCount (zoneStats) {
+  // sum up all values in JavaScript Object
+  // https://stackoverflow.com/questions/16449295/how-to-sum-the-values-of-a-javascript-object
+  const zoningPieceCount = Object.values(zoneStats).reduce((a, b) => a + b, 0);
 
-async function updateMapLayer () {
-  const query = featureToQuery.createQuery();
-
-  query.geometry = sketchGeometry;
-  query.distance = bufferSize;
-
-  const objectIds = await featureToQuery.queryObjectIds(query);
-
-  changeFeatureCount(objectIds);
+  document.getElementById("count").innerHTML = zoningPieceCount;
 }
 
 /* sidebar */

--- a/app/main.js
+++ b/app/main.js
@@ -129,6 +129,7 @@ view.ui.add(scaleBar, {
 
 const queryPanel = document.getElementById("queryDiv");
 
+// Show the "Query by geometry" panel only after zoning polygons are loaded
 zone
   .load()
   .then(() => {
@@ -335,6 +336,15 @@ const debouncedCalculateZoningArea = debounce((selectedZonings) => {
   return calculateAreaByZoning(selectedZonings);
 });
 
+// runQuery() Conduct the following tasks:
+// 1. Update the geometry buffer graphic layer on map
+// 2. Update buffer size
+// 3. Get area of each zoning intersects with buffer
+// 4. Update zoningAreaChart
+// 5. Query statstics inside the buffer
+// 6. Update zoningNumberChart
+// 7. Update number of zoning pieces shown
+// 8. Scroll to the charts
 async function runQuery () {
   // Update the view of buffer graphic layer on map
   updateBufferGraphic(bufferSize, sketchGeometry, bufferLayer);
@@ -398,6 +408,9 @@ async function calculateAreaByZoning (selectedZonings) {
 
   console.timeEnd("test_parallel");
 
+  // compute OZP-covered area in the geometry
+  // TODO: Create separate function to handle the task
+
   // cannot directly add up selectedZoningAreas since it only includes values of SELECTED zonings
   const totalAreaInOZP = await getZoningAreaInBuffer(bufferSize);
   console.log("totalAreaInOZP: ", totalAreaInOZP);
@@ -453,9 +466,6 @@ function updateQueryGeomSize (queryGeom, buffer) {
 
 // TODO: to improve, find ways to clip FeatureLayer by Graphics, GeometryEngine seems only works with graphics
 async function getZoningAreaInBuffer (bufferLength, zoning) {
-  // console.log("sketchGeometry: ", sketchGeometry);
-  // console.log("bufferLength === 0:", bufferLength === 0);
-
   // TODO: test if Only execute function when buffer has actual size?
   // TODO: write unit test
 
@@ -482,9 +492,6 @@ async function getZoningAreaInBuffer (bufferLength, zoning) {
   }
 
   const results = await featureToQuery.queryFeatures(query);
-
-  // console.log("Queried zoning intersects with buffer");
-  // console.log(results);
 
   // Check if any features intersect with the buffer
   // If no, length of results will be 0, i.e. area in buffer = 0
@@ -513,8 +520,6 @@ async function getZoningAreaInBuffer (bufferLength, zoning) {
     // console.log("intersect function performed");
 
     areaInBuffer = await geodesicArea(bufferOZPIntersect, "square-meters");
-    // console.log("getZoningAreaInBuffer(): area calculated");
-    // console.log("areaInBuffer: ", areaInBuffer);
   }
 
   return areaInBuffer;

--- a/app/main.js
+++ b/app/main.js
@@ -1,4 +1,5 @@
 import { changeMenuIcon, showSidePanel } from "./ui";
+import { queryStatistics } from "./query-zoning";
 import { zoningNumberChart, zoningAreaChart, updateChart, clearCharts } from "./create-chart";
 
 
@@ -334,7 +335,7 @@ const debouncedRunQuery = debounce(function () {
   calculateAreaByZoning();
 
   return eachAlways([
-    queryStatistics(),
+    queryStatistics(featureToQuery, sketchGeometry, bufferSize),
     updateMapLayer()
   ]);
 });
@@ -585,76 +586,6 @@ function updateMapLayer () {
   return featureToQuery.queryObjectIds(query).then(changeFeatureCount);
   // return webLayerView.queryObjectIds(query).then(highlightGeometries);
 }
-
-const statDefinitions = [{
-  onStatisticField: "CASE WHEN ZONE_MAS = 'R(A)' THEN 1 ELSE 0 END",
-  outStatisticFieldName: "zone_RA",
-  statisticType: "sum"
-},
-{
-  onStatisticField: "CASE WHEN ZONE_MAS = 'R(B)' THEN 1 ELSE 0 END",
-  outStatisticFieldName: "zone_RB",
-  statisticType: "sum"
-},
-{
-  onStatisticField: "CASE WHEN ZONE_MAS = 'R(C)' THEN 1 ELSE 0 END",
-  outStatisticFieldName: "zone_RC",
-  statisticType: "sum"
-},
-{
-  onStatisticField: "CASE WHEN ZONE_MAS = 'G/IC' THEN 1 ELSE 0 END",
-  outStatisticFieldName: "zone_GIC",
-  statisticType: "sum"
-},
-{
-  onStatisticField: "CASE WHEN ZONE_MAS = 'O' THEN 1 ELSE 0 END",
-  outStatisticFieldName: "zone_O",
-  statisticType: "sum"
-},
-{
-  onStatisticField: "CASE WHEN ZONE_MAS = 'C' THEN 1 ELSE 0 END",
-  outStatisticFieldName: "zone_C",
-  statisticType: "sum"
-},
-{
-  onStatisticField: "CASE WHEN ZONE_MAS = 'MRDJ' THEN 1 ELSE 0 END",
-  outStatisticFieldName: "zone_MRDJ",
-  statisticType: "sum"
-},
-{
-  onStatisticField: "CASE WHEN ZONE_MAS NOT IN ('R(A)', 'R(B)', 'R(C)', 'G/IC', 'O', 'C', 'MRDJ') THEN 1 ELSE 0 END",
-  outStatisticFieldName: "zone_OTHERS",
-  statisticType: "sum"
-}
-];
-
-function queryStatistics () {
-  // https://developers.arcgis.com/javascript/latest/api-reference/esri-tasks-support-Query.html
-  const query = featureToQuery.createQuery();
-
-  query.geometry = sketchGeometry;
-  query.distance = bufferSize;
-  query.outStatistics = statDefinitions;
-
-  // with outStatistics returned result is a "table" with geometry of null
-  return featureToQuery.queryFeatures(query).then(function (result) {
-    // console.log(result);
-
-    const allStats = result.features[0].attributes;
-
-    updateChart(zoningNumberChart, [
-      allStats.zone_RA,
-      allStats.zone_RB,
-      allStats.zone_RC,
-      allStats.zone_GIC,
-      allStats.zone_O,
-      allStats.zone_C,
-      allStats.zone_MRDJ,
-      allStats.zone_OTHERS
-    ]);
-  }, console.error);
-}
-
 
 /* sidebar */
 

--- a/app/main.js
+++ b/app/main.js
@@ -21,9 +21,66 @@ const map = new Map({
   basemap: "gray-vector"
 });
 
+const zonePopupTemplate = new PopupTemplate({
+  title: "Zoning Details",
+  defaultPopupTemplateEnabled: true,
+  content: [
+    {
+      type: "fields",
+      fieldInfos: [
+        {
+          fieldName: "ZONE_LABEL",
+          label: "ZONE_LABEL"
+        },
+        {
+          fieldName: "DESC_ENG",
+          label: "DESC_ENG"
+        },
+        {
+          fieldName: "DESC_CHT",
+          label: "DESC_CHT"
+        },
+        {
+          fieldName: "SPUSE_ENG",
+          label: "SPUSE_ENG"
+        },
+        {
+          fieldName: "SPUSE_CHT",
+          label: "SPUSE_CHT"
+        },
+        {
+          fieldName: "PLAN_NO",
+          label: "PLAN_NO"
+        },
+        {
+          fieldName: "NAME_ENG",
+          label: "NAME_ENG"
+        },
+        {
+          fieldName: "NAME_CHT",
+          label: "NAME_CHT"
+        },
+        {
+          fieldName: "PUB_DATE",
+          label: "PUB_DATE"
+        },
+        {
+          fieldName: "APRV_DATE",
+          label: "APRV_DATE"
+        },
+        {
+          fieldName: "SECT_NO",
+          label: "SECT_NO"
+        }
+      ]
+    }
+  ]
+});
+
 const zone = new FeatureLayer({
   url: "https://services5.arcgis.com/xH8UmTNerx1qYfXM/ArcGIS/rest/services/ZONE_MASTER_LATEST/FeatureServer",
-  outFields: ["*"]
+  outFields: ["*"],
+  popupTemplate: zonePopupTemplate
 });
 
 const schemeArea = new FeatureLayer({

--- a/app/main.js
+++ b/app/main.js
@@ -1,4 +1,4 @@
-import { changeMenuIcon } from "./ui";
+import { changeMenuIcon, showSidePanel } from "./ui";
 import { zoningNumberChart, zoningAreaChart, updateChart, clearCharts } from "./create-chart";
 
 
@@ -298,15 +298,6 @@ function bufferVariablesChanged (event) {
 document
   .getElementById("clearResults")
   .addEventListener("click", clearResults);
-
-// Show sidePanel again if folded
-// do not use it when users are changing buffer variables only
-function showSidePanel () {
-  const sidebar = document.querySelector(".sidebar");
-
-  // If a class that the element is already a member of is added, classList.add will ignore it
-  sidebar.classList.add("open");
-}
 
 // Clear the geometry and set the default renderer
 // Reset all to default

--- a/app/query-zoning.js
+++ b/app/query-zoning.js
@@ -55,15 +55,6 @@ export function queryStatistics (zoningFeature, sketchGeometry, bufferSize) {
 
     const allStats = result.features[0].attributes;
 
-    updateChart(zoningNumberChart, [
-      allStats.zone_RA,
-      allStats.zone_RB,
-      allStats.zone_RC,
-      allStats.zone_GIC,
-      allStats.zone_O,
-      allStats.zone_C,
-      allStats.zone_MRDJ,
-      allStats.zone_OTHERS
-    ]);
+    return allStats;
   }, console.error);
 }

--- a/app/query-zoning.js
+++ b/app/query-zoning.js
@@ -1,0 +1,69 @@
+
+const statDefinitions = [{
+  onStatisticField: "CASE WHEN ZONE_MAS = 'R(A)' THEN 1 ELSE 0 END",
+  outStatisticFieldName: "zone_RA",
+  statisticType: "sum"
+},
+{
+  onStatisticField: "CASE WHEN ZONE_MAS = 'R(B)' THEN 1 ELSE 0 END",
+  outStatisticFieldName: "zone_RB",
+  statisticType: "sum"
+},
+{
+  onStatisticField: "CASE WHEN ZONE_MAS = 'R(C)' THEN 1 ELSE 0 END",
+  outStatisticFieldName: "zone_RC",
+  statisticType: "sum"
+},
+{
+  onStatisticField: "CASE WHEN ZONE_MAS = 'G/IC' THEN 1 ELSE 0 END",
+  outStatisticFieldName: "zone_GIC",
+  statisticType: "sum"
+},
+{
+  onStatisticField: "CASE WHEN ZONE_MAS = 'O' THEN 1 ELSE 0 END",
+  outStatisticFieldName: "zone_O",
+  statisticType: "sum"
+},
+{
+  onStatisticField: "CASE WHEN ZONE_MAS = 'C' THEN 1 ELSE 0 END",
+  outStatisticFieldName: "zone_C",
+  statisticType: "sum"
+},
+{
+  onStatisticField: "CASE WHEN ZONE_MAS = 'MRDJ' THEN 1 ELSE 0 END",
+  outStatisticFieldName: "zone_MRDJ",
+  statisticType: "sum"
+},
+{
+  onStatisticField: "CASE WHEN ZONE_MAS NOT IN ('R(A)', 'R(B)', 'R(C)', 'G/IC', 'O', 'C', 'MRDJ') THEN 1 ELSE 0 END",
+  outStatisticFieldName: "zone_OTHERS",
+  statisticType: "sum"
+}
+];
+
+export function queryStatistics (zoningFeature, sketchGeometry, bufferSize) {
+  // https://developers.arcgis.com/javascript/latest/api-reference/esri-tasks-support-Query.html
+  const query = zoningFeature.createQuery();
+
+  query.geometry = sketchGeometry;
+  query.distance = bufferSize;
+  query.outStatistics = statDefinitions;
+
+  // with outStatistics returned result is a "table" with geometry of null
+  return zoningFeature.queryFeatures(query).then(function (result) {
+    // console.log(result);
+
+    const allStats = result.features[0].attributes;
+
+    updateChart(zoningNumberChart, [
+      allStats.zone_RA,
+      allStats.zone_RB,
+      allStats.zone_RC,
+      allStats.zone_GIC,
+      allStats.zone_O,
+      allStats.zone_C,
+      allStats.zone_MRDJ,
+      allStats.zone_OTHERS
+    ]);
+  }, console.error);
+}

--- a/app/ui.js
+++ b/app/ui.js
@@ -8,3 +8,12 @@ export function changeMenuIcon (sidebar, collapseBtn) {
 }
 
 document.getElementById("lastModified").innerHTML = document.lastModified;
+
+// Show sidePanel again if folded
+// do not use it when users are changing buffer variables only
+export function showSidePanel () {
+  const sidebar = document.querySelector(".sidebar");
+
+  // If a class that the element is already a member of is added, classList.add will ignore it
+  sidebar.classList.add("open");
+}


### PR DESCRIPTION
- Move functions to separate files
- Rewrite the `calculateAreaByZoning` function and drops out unnecessary async/await

---

### Note

`runQuery()` is the overall wrapping function to change the webpage for every user's action. Future dev could focus on breaking down the changes in separate functions and include in `runQuery()`.