### PR TITLE
Fix: Fix `npm ci` install errors

### DIFF
--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-      - run: npm ci
+      - run: npm ci --legacy-peer-deps
       - run: npm run build
       
       - name: Deploy 🚀

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -28,5 +28,5 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-      - run: npm ci
+      - run: npm ci --legacy-peer-deps
       - run: npm run build


### PR DESCRIPTION
Same as https://github.com/KHwong12/viewshed-peaks/pull/112. Error introduced after bug fix in npm v8.6.

ubuntu-latest is using npm 8.11.0 [as of 2022-06-30](https://github.com/actions/virtual-environments/blob/7ff67b1a39fecb4c7965a305dc715676ecded01f/images/linux/Ubuntu2004-Readme.md). Local machine is using npm 8.3.1, thus it is able to build the website on local machine.