### PR TITLE
feat: Use latest ver. of scheme area feature layer

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -85,7 +85,7 @@ const zone = new FeatureLayer({
 });
 
 const schemeArea = new FeatureLayer({
-  url: "https://services5.arcgis.com/xH8UmTNerx1qYfXM/arcgis/rest/services/PLAN_SCHEME_AREA_20220224/FeatureServer",
+  url: "https://services5.arcgis.com/xH8UmTNerx1qYfXM/arcgis/rest/services/PLAN_SCHEME_AREA_LATEST/FeatureServer",
   outFields: ["*"]
 });
 


### PR DESCRIPTION
A new feature layer dedicated to store the "latest" version of the scheme area is created in AGOL. This layer will be updated every time when a new plan is gazetted (by overwriting the old version of data), thus having the `_LATEST` suffix.

The zoning data in this web app is expected to use the latest available OZP.

https://services5.arcgis.com/xH8UmTNerx1qYfXM/arcgis/rest/services/PLAN_SCHEME_AREA_LATEST/FeatureServer 